### PR TITLE
feat: Adding functionality to collapse the directory sidebar on click of collapse button in footer

### DIFF
--- a/.changeset/curvy-files-tie.md
+++ b/.changeset/curvy-files-tie.md
@@ -1,0 +1,5 @@
+---
+"flowtestai": minor
+---
+
+Collapse sidebar to give more real estate to canvas

--- a/src/components/layouts/SplitPane.js
+++ b/src/components/layouts/SplitPane.js
@@ -4,15 +4,32 @@ import 'allotment/dist/style.css';
 import Workspace from '../organisms/workspace/Workspace';
 import AppNavBar from 'components/organisms/AppNavBar';
 import SideBar from 'components/organisms/SideBar';
+import useNavigationStore from 'stores/AppNavBarStore';
+import { AppNavBarStyles } from 'constants/AppNavBar';
 
 const SplitPane = () => {
+  const isNavBarCollapsed = useNavigationStore((state) => state.collapseNavBar);
   return (
     <main className='h-full'>
       <Allotment>
-        <Allotment.Pane preferredSize={'450px'} minSize={450}>
-          <div className='flex text-xs'>
+        <Allotment.Pane
+          minSize={isNavBarCollapsed ? AppNavBarStyles.collapsedNavBarWidth.absolute : 450}
+          maxSize={isNavBarCollapsed ? AppNavBarStyles.collapsedNavBarWidth.absolute : 600}
+          separator={isNavBarCollapsed ? false : true}
+        >
+          <div className='flex h-full text-xs'>
             <AppNavBar />
-            <SideBar />
+            {!isNavBarCollapsed ? (
+              <div className='h-full w-full'>
+                <Allotment>
+                  <Allotment.Pane>
+                    <SideBar />
+                  </Allotment.Pane>
+                </Allotment>
+              </div>
+            ) : (
+              ''
+            )}
           </div>
         </Allotment.Pane>
         <Allotment.Pane>

--- a/src/components/layouts/SplitPane.js
+++ b/src/components/layouts/SplitPane.js
@@ -13,6 +13,7 @@ const SplitPane = () => {
     <main className='h-full'>
       <Allotment>
         <Allotment.Pane
+          preferredSize={isNavBarCollapsed ? AppNavBarStyles.collapsedNavBarWidth.absolute : 450}
           minSize={isNavBarCollapsed ? AppNavBarStyles.collapsedNavBarWidth.absolute : 450}
           maxSize={isNavBarCollapsed ? AppNavBarStyles.collapsedNavBarWidth.absolute : 600}
           separator={isNavBarCollapsed ? false : true}
@@ -20,7 +21,7 @@ const SplitPane = () => {
           <div className='flex h-full text-xs'>
             <AppNavBar />
             {!isNavBarCollapsed ? (
-              <div className='h-full w-full'>
+              <div className='w-full h-full'>
                 <Allotment>
                   <Allotment.Pane>
                     <SideBar />

--- a/src/components/molecules/footers/MainFooter.js
+++ b/src/components/molecules/footers/MainFooter.js
@@ -6,24 +6,25 @@ import useCollectionStore from 'stores/CollectionStore';
 
 const MainFooter = () => {
   const collections = useCollectionStore((state) => state.collections);
-  const collapseNavBarValue = useNavigationStore((state) => state.collapseNavBar);
+  const isNavBarCollapsed = useNavigationStore((state) => state.collapseNavBar);
   const updateNavCollapseState = useNavigationStore((state) => state.setNavCollapseState);
   return (
     <footer className='flex items-center justify-between px-6 py-2 text-xs'>
-      <label className='py-1 cursor-pointer swap swap-rotate'>
+      <label className='swap swap-rotate cursor-pointer py-1'>
         <input
           type='checkbox'
           onClick={(event) => {
             if (collections.length) {
-              updateNavCollapseState(!collapseNavBarValue);
+              // since default is false for isNavBarCollapsed
+              updateNavCollapseState(!isNavBarCollapsed);
             } else {
               event.preventDefault();
               event.stopPropagation();
             }
           }}
         />
-        <ArrowRightStartOnRectangleIcon className='w-6 h-6 swap-on' />
-        <ArrowLeftEndOnRectangleIcon className='w-6 h-6 swap-off' />
+        <ArrowRightStartOnRectangleIcon className='swap-on h-6 w-6' />
+        <ArrowLeftEndOnRectangleIcon className='swap-off h-6 w-6' />
       </label>
       <div className='flex items-center justify-between gap-4 font-semibold'>
         <Tippy content='External Link' placement='top'>

--- a/src/components/molecules/sidebar/content/Collections.js
+++ b/src/components/molecules/sidebar/content/Collections.js
@@ -59,7 +59,7 @@ const Collections = ({ collections }) => {
 
   return (
     <div
-      className='h-[87vh] flex-auto overflow-auto'
+      className='h-[87vh] flex-auto overflow-auto pb-14'
       onClick={(event) => {
         const clickFromElementDataSet = event.target.dataset;
         const clickFrom = clickFromElementDataSet?.clickFrom;

--- a/src/components/molecules/sidebar/content/Environments.js
+++ b/src/components/molecules/sidebar/content/Environments.js
@@ -12,7 +12,7 @@ const Environments = ({ collections }) => {
 
   return (
     <div
-      className='h-[87vh] flex-auto overflow-auto'
+      className='h-[87vh] flex-auto overflow-auto pb-14'
       onClick={(event) => {
         const clickFromElementDataSet = event.target.dataset;
         const clickFrom = clickFromElementDataSet?.clickFrom;
@@ -38,7 +38,7 @@ const Environments = ({ collections }) => {
         }
       }}
     >
-      <ul className='w-full menu'>
+      <ul className='menu w-full'>
         {collections.map((collection) => (
           <Environment key={collection.id} collectionId={collection.id} collection={collection} />
         ))}

--- a/src/components/organisms/AppNavBar.js
+++ b/src/components/organisms/AppNavBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Square3Stack3DIcon, RectangleStackIcon, ClockIcon } from '@heroicons/react/20/solid';
 import useNavigationStore from 'stores/AppNavBarStore';
-import { AppNavBarItems } from 'constants/AppNavBar';
+import { AppNavBarItems, AppNavBarStyles } from 'constants/AppNavBar';
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
 import { Transition } from '@headlessui/react';
@@ -10,7 +10,7 @@ import { Transition } from '@headlessui/react';
 const AppNavBar = ({ showRightBorder = true }) => {
   const navigationSelectedValue = useNavigationStore((state) => state.selectedNavVal);
   const updateNavigationSelectedValue = useNavigationStore((state) => state.setNavState);
-  const collapseNavBarValue = useNavigationStore((state) => state.collapseNavBar);
+  const isNavBarCollapsed = useNavigationStore((state) => state.collapseNavBar);
 
   const handleOnClick = (event) => {
     const dataAttributeValue = event.currentTarget.dataset.navItem;
@@ -19,9 +19,10 @@ const AppNavBar = ({ showRightBorder = true }) => {
 
   const selectedNavItemStyles = 'before:bg-cyan-900 bg-background text-cyan-900';
   const nonSelectedNavItemStyles = 'hover:bg-cyan-900 hover:text-white';
+  const navStyles = 'relative flex h-screen flex-col transition-all delay-150 duration-300';
   return (
     <nav
-      className={`relative flex h-screen flex-col transition-all delay-150 duration-300 ${collapseNavBarValue ? 'min-w-14' : 'min-w-28'} ${showRightBorder ? 'border-r border-gray-300' : ''}`}
+      className={`${navStyles} ${isNavBarCollapsed ? AppNavBarStyles.collapsedNavBarWidth.tailwindValue.min : AppNavBarStyles.expandedNavBarWidth.tailwindValue.min} ${showRightBorder && !isNavBarCollapsed ? 'border-r border-gray-300' : ''}`}
     >
       <button className='relative' onClick={handleOnClick} data-nav-item={AppNavBarItems.collections.value}>
         <div
@@ -31,15 +32,15 @@ const AppNavBar = ({ showRightBorder = true }) => {
               : nonSelectedNavItemStyles
           } delay-50 flex w-full flex-col items-center px-2 py-4 text-center transition-all duration-100`}
         >
-          {collapseNavBarValue ? (
+          {isNavBarCollapsed ? (
             <Tippy content={AppNavBarItems.collections.displayValue} placement='right'>
-              <RectangleStackIcon className='w-4 h-4 mb-2' />
+              <RectangleStackIcon className='mb-2 h-4 w-4' />
             </Tippy>
           ) : (
-            <RectangleStackIcon className='w-4 h-4 mb-2' />
+            <RectangleStackIcon className='mb-2 h-4 w-4' />
           )}
           <Transition
-            show={!collapseNavBarValue}
+            show={!isNavBarCollapsed}
             enter='transition-all ease-in-out duration-500 delay-[200ms]'
             enterFrom='opacity-0 translate-y-6'
             enterTo='opacity-100 translate-y-0'
@@ -59,15 +60,15 @@ const AppNavBar = ({ showRightBorder = true }) => {
               : nonSelectedNavItemStyles
           } delay-50 flex w-full flex-col items-center px-2 py-4 text-center transition-all duration-100`}
         >
-          {collapseNavBarValue ? (
+          {isNavBarCollapsed ? (
             <Tippy content={AppNavBarItems.environments.displayValue} placement='right'>
-              <Square3Stack3DIcon className='w-4 h-4 mb-2' />
+              <Square3Stack3DIcon className='mb-2 h-4 w-4' />
             </Tippy>
           ) : (
-            <Square3Stack3DIcon className='w-4 h-4 mb-2' />
+            <Square3Stack3DIcon className='mb-2 h-4 w-4' />
           )}
           <Transition
-            show={!collapseNavBarValue}
+            show={!isNavBarCollapsed}
             enter='transition-all ease-in-out duration-500 delay-[200ms]'
             enterFrom='opacity-0 translate-y-6'
             enterTo='opacity-100 translate-y-0'
@@ -79,25 +80,25 @@ const AppNavBar = ({ showRightBorder = true }) => {
           </Transition>
         </div>
       </button>
-      <button className='px-2 py-4 cursor-not-allowed ' data-nav-item={AppNavBarItems.history.value}>
+      <button className='cursor-not-allowed px-2 py-4 ' data-nav-item={AppNavBarItems.history.value}>
         <div className='text-gray-300'>
-          {collapseNavBarValue ? (
-            <div className='transition-all duration-300 delay-150'>
+          {isNavBarCollapsed ? (
+            <div className='transition-all delay-150 duration-300'>
               <Tippy content={AppNavBarItems.history.displayValue + ': Coming Soon!'} placement='right'>
                 <div className='flex flex-col items-center text-center '>
-                  <ClockIcon className='w-4 h-4 mb-2' />
+                  <ClockIcon className='mb-2 h-4 w-4' />
                 </div>
               </Tippy>
             </div>
           ) : (
             <Tippy content='Coming Soon!' placement='right'>
               <div className='flex flex-col items-center text-center '>
-                <ClockIcon className='w-4 h-4 mb-2' />
+                <ClockIcon className='mb-2 h-4 w-4' />
               </div>
             </Tippy>
           )}
           <Transition
-            show={!collapseNavBarValue}
+            show={!isNavBarCollapsed}
             enter='transition-all ease-in-out duration-500 delay-[200ms]'
             enterFrom='opacity-0 translate-y-6'
             enterTo='opacity-100 translate-y-0'

--- a/src/constants/AppNavBar.js
+++ b/src/constants/AppNavBar.js
@@ -19,3 +19,22 @@ export const AppNavBarItems = {
     disable: true,
   },
 };
+
+export const AppNavBarStyles = {
+  collapsedNavBarWidth: {
+    absolute: 56,
+    pixelInString: '56px',
+    tailwindValue: {
+      default: 'w-14',
+      min: 'min-w-14',
+    },
+  },
+  expandedNavBarWidth: {
+    absolute: 12,
+    pixelInString: '12px',
+    tailwindValue: {
+      default: 'w-28',
+      min: 'min-w-28',
+    },
+  },
+};


### PR DESCRIPTION
**Description**
**Current Behaviour:** As of now when a user clicks on the collapse icon or button in the main footer, we collapse the App Nav bar to show only Icons. 

**New Behaviour:** We also wants to hide the directory Side bar when user wants to collapse the App nav bar to provide more real state for the flow or environment file content and show it when user expands the App nav bar

**Linear task:**
* https://linear.app/flowtest/issue/FLO-153